### PR TITLE
chore(privacy): rotate PII hash salt

### DIFF
--- a/tools/config/privacy-policy.json
+++ b/tools/config/privacy-policy.json
@@ -1,6 +1,7 @@
 {
-  "hash_salt": "c886875c5797cfcdbe872399551b6ade",
+  "hash_salt": "ce4235e8542943c9096b1b9fdd791932",
   "previous_salts": [
+    "c886875c5797cfcdbe872399551b6ade",
     "acb0f8a3e5468210ae2dd2a437551a81",
     "cb098a12b5fd2c327d522ba048c16b40",
     "8588258e2114b3177631d1ad42c05605",
@@ -9,5 +10,5 @@
   ],
   "multi_category_block_threshold": 2,
   "sample_truncate_chars": 6,
-  "last_rotated_utc": "2025-08-18T08:56:34.958Z"
+  "last_rotated_utc": "2025-08-19T08:51:48.385Z"
 }


### PR DESCRIPTION
Automated daily rotation of PII hash salt.

- Updates `tools/config/privacy-policy.json`
- Keeps last 14 salts in history
- See rotation artifact in the workflow run